### PR TITLE
docs: fix instructions to use yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,25 +86,13 @@ Suggested environment:
 
 ##### Install dependencies
 
-For NPM v6 or above:
-
 ```bash
-npm ci
-```
-
-For NPM before v6
-
-```bash
-npm install
+yarn install
 ```
 
 ##### Start development
 
-YiNote leverages [Lerna](https://github.com/lerna/lerna) to manage the monorepo.
-
-Please run `npm run bootstrap` to setup dependecies for each sub_modules before start.
-
-Then run `npm start` will start both `extension` and `playground` in development mode.
+Run `yarn start:ext`.
 
 For `content script` change, you need to reload the extension in `chrome://extensions` tab.
 


### PR DESCRIPTION
Since you switched to yarn in #82, `npm install` no longer works.
Let new contributors get started with appropriate instructions.

This PR should also close #85.